### PR TITLE
JDBC_PING: Add Configuration for SQL-Server

### DIFF
--- a/12.0.4/cli/JDBC_PING.cli
+++ b/12.0.4/cli/JDBC_PING.cli
@@ -39,7 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    echo "Database sqlserver not supported yet"
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/12.0.4/cli/JDBC_PING.cli
+++ b/12.0.4/cli/JDBC_PING.cli
@@ -39,10 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; CREATE TABLE ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/13.0.1/cli/JDBC_PING.cli
+++ b/13.0.1/cli/JDBC_PING.cli
@@ -39,7 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    echo "Database sqlserver not supported yet"
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/13.0.1/cli/JDBC_PING.cli
+++ b/13.0.1/cli/JDBC_PING.cli
@@ -39,10 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; CREATE TABLE ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/14.0.0/cli/JDBC_PING.cli
+++ b/14.0.0/cli/JDBC_PING.cli
@@ -39,7 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    echo "Database sqlserver not supported yet"
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/14.0.0/cli/JDBC_PING.cli
+++ b/14.0.0/cli/JDBC_PING.cli
@@ -39,10 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; CREATE TABLE ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/15.0.0/cli/JDBC_PING.cli
+++ b/15.0.0/cli/JDBC_PING.cli
@@ -39,7 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    echo "Database sqlserver not supported yet"
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/15.0.0/cli/JDBC_PING.cli
+++ b/15.0.0/cli/JDBC_PING.cli
@@ -39,10 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; CREATE TABLE ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/15.0.1/cli/JDBC_PING.cli
+++ b/15.0.1/cli/JDBC_PING.cli
@@ -39,7 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    echo "Database sqlserver not supported yet"
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/15.0.1/cli/JDBC_PING.cli
+++ b/15.0.1/cli/JDBC_PING.cli
@@ -39,10 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; CREATE TABLE ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/15.0.2/cli/JDBC_PING.cli
+++ b/15.0.2/cli/JDBC_PING.cli
@@ -39,7 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    echo "Database sqlserver not supported yet"
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/15.0.2/cli/JDBC_PING.cli
+++ b/15.0.2/cli/JDBC_PING.cli
@@ -39,10 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; CREATE TABLE ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/15.1.1/cli/JDBC_PING.cli
+++ b/15.1.1/cli/JDBC_PING.cli
@@ -39,7 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    echo "Database sqlserver not supported yet"
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/15.1.1/cli/JDBC_PING.cli
+++ b/15.1.1/cli/JDBC_PING.cli
@@ -39,10 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; CREATE TABLE ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/16.1.0/cli/JDBC_PING.cli
+++ b/16.1.0/cli/JDBC_PING.cli
@@ -39,7 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    echo "Database sqlserver not supported yet"
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try

--- a/16.1.0/cli/JDBC_PING.cli
+++ b/16.1.0/cli/JDBC_PING.cli
@@ -39,10 +39,10 @@ if (outcome == success && result == oracle) of /subsystem=datasources/data-sourc
 end-if
 
 if (outcome == success && result == sqlserver) of /subsystem=datasources/data-source=KeycloakDS:read-attribute(name=driver-name)
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES  WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING') CREATE TABLE ${env.DB_SCHEMA:public}.JGROUPSPING ( own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:public}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
-    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=initialize_sql:add(value="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; CREATE TABLE ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name))")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=insert_single_sql:add(value="INSERT INTO ${env.DB_SCHEMA:dbo}.JGROUPSPING (own_addr, bind_addr, cluster_name, updated, ping_data) values (?, '${jgroups.tcp.address:127.0.0.1}', ?, GETDATE(), ?)")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=delete_single_sql:add(value="DELETE FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?")
+    /subsystem=jgroups/stack=tcp/protocol=JDBC_PING/property=select_all_pingdata_sql:add(value="SELECT ping_data, own_addr, cluster_name FROM ${env.DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?")
 end-if
 
 try


### PR DESCRIPTION
I just happened to configure keycloak in ha mode for SQL Server.

I must admit, I haven't used JDBC_PING.cli, but directly configured it
using standalone-ha.xml. But since this is just for the properties
'initialize_sql', 'insert_sql', 'delete_sql' and 'select_all_pingdata'
I copied my statements from the configuration file back to the
JDBC_PING.cli.

Note: I have added the bind_addr as property into the table, because I
think this is actually quite useful.

Also Note: I have dropped the part about creating the schema¹. Because
from my understanding, if the Schema isn't there, Keycloak wouldn't
start at all at least if the JGROUPSPING table is located in the same
schema as all the keycloak tables.

The provided SQL Statements are working for me with SQL Server 2017
tested with 2 keycloaks 13.0.1.

Apparently, it looks like the JDBC_PING.cli is the same for all
different keycloak servers, so I just changed one and copied it over
all other copies :)

¹)
For reference the following SQL could be used to create the schema as
well:
```SQL
IF NOT EXISTS
(SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME=${env.DB_SCHEMA:public})
EXEC ('CREATE SCHEMA ${env.DB_SCHEMA:public}');
```

But, when adding this before all the other initialize_sqls, keycloak
didn't create anything at all. Most likely, SQL Server didn't like this
statement and the other ones after each other and since I didn't notice
any error message, I didn't investigate further.